### PR TITLE
Fixed gretty version 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
 
     // gretty is a gradle plugin to make it easy to run a server and hotswap code at runtime.
     // https://plugins.gradle.org/plugin/org.gretty
-    id 'org.gretty' version '3.0.4'
+    id 'org.gretty' version '3.1.5'
 
     // provides access to a database versioning tool.
     id "org.flywaydb.flyway" version "6.0.8"


### PR DESCRIPTION
The gretty version was fixed because the current version of 3.0.4 is no longer supported.